### PR TITLE
Unwrap `TargetInvocationException` to get error details

### DIFF
--- a/NetCore/NetCoreRepro/Program.cs
+++ b/NetCore/NetCoreRepro/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace NetCoreRepro
@@ -36,8 +37,17 @@ namespace NetCoreRepro
                 foreach (Exception innerException in ex.InnerExceptions)
                 {
                     Console.Error.WriteLine();
-                    Console.Error.WriteLine(innerException.Message);
-                    Console.Error.WriteLine(innerException.StackTrace);
+
+                    if (innerException is TargetInvocationException tiex)
+                    {
+                        Console.Error.WriteLine(tiex.InnerException.Message);
+                        Console.Error.WriteLine(tiex.InnerException.StackTrace);
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine(innerException.Message);
+                        Console.Error.WriteLine(innerException.StackTrace);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If you invoke a method using reflection, and that method throws an exception, you'll get back a `TargetInvocationException`. The actual error is hidden inside its `InnerException`. This adds code to "unwrap" `TargetInvocationException`s.